### PR TITLE
fix the precedence of keybindings

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -106,12 +106,13 @@ export class GalapagosEditor {
     // Keybindings
     var KeyBindings = Options.KeyBindings ?? [];
     if (this.Options.OneLine) {
-      if (KeyBindings.findIndex((Binding) => Binding.key === 'Enter') === -1)
-        KeyBindings.push({ key: 'Enter', run: () => true });
-      if (KeyBindings.findIndex((Binding) => Binding.key === 'Tab') === -1)
-        KeyBindings.push({ key: 'Tab', run: acceptCompletion });
+      KeyBindings.push({ key: 'Enter', run: () => true });
     }
-    Extensions.push(keymap.of(KeyBindings));
+    KeyBindings.push({ key: 'Tab', run: acceptCompletion });
+    if (!this.Options.OneLine) {
+      KeyBindings.push(indentWithTab);
+    }
+    Extensions.push(Prec.highest(keymap.of(KeyBindings)));
     // DOM handlers
     Extensions.push(
       EditorView.domEventHandlers({


### PR DESCRIPTION
- added `Prec.highest` to allow additional keybindings to override default keybindings even though they are specified later in the Extensions array.
- removed check that would not add Enter and Tab keybindings if additional keybindings were already specified for those keys. this check was unnecessary and prevented the user from allowing additional keybindings to fall back to existing keybindings.
- allowed non-OneLine editors to use autocompletion